### PR TITLE
Handle index sorting.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/MutablePointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/MutablePointValues.java
@@ -48,13 +48,4 @@ public abstract class MutablePointValues extends PointValues {
   /** Restore values between i-th and j-th(excluding) in temporary storage into original storage. */
   public abstract void restore(int i, int j);
 
-  /**
-   * If index sorting is enabled for field, reorder i-th to j-th(excluding)
-   * based on sortMap without having to sort (ie. O(n) rather than O(n log n)).
-   *
-   * @return true if index sorting works, else false.
-   */
-  public boolean indexSortingReorder(int i, int j) {
-    return false;
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/PointValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValuesWriter.java
@@ -314,13 +314,5 @@ class PointValuesWriter {
       in.restore(i, j);
     }
 
-    @Override
-    public boolean indexSortingReorder(int i, int j) {
-      for (int k = i; k < j; k++) {
-        save(in.getDocID(i), docMap.oldToNew(in.getDocID(i)));
-      }
-      restore(i, j);
-      return true;
-    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestBKD.java
@@ -1696,7 +1696,9 @@ public class TestBKD extends LuceneTestCase {
 
           @Override
           public byte getByteAt(int i, int k) {
-            throw new UnsupportedOperationException();
+            BytesRef b = new BytesRef();
+            getValue(i, b);
+            return b.bytes[b.offset + k];
           }
 
           @Override


### PR DESCRIPTION
I wanted to look into your PR more to see how we should handle index sorting, and I don't feel good about requiring doc IDs to be in ascending order, so I'm proposing this approach as a first step, and we could look into making things better in a follow-up? I'm still looking significant improvements when running your benchmark:

```
 -------------------------------------------------
| bytesPerDim | isDocIdIncremental | avg time(us) |
 -------------------------------------------------
|      1      |         N          |    304884.5  |
|      1      |         Y          |     18424.9  |
|      2      |         N          |    330947.7  |
|      2      |         Y          |     96570.9  |
|      3      |         N          |    340522.7  |
|      3      |         Y          |    216692.9  |
|      4      |         N          |    303581.8  |
|      4      |         Y          |    316861.3  |
|      8      |         N          |    320299.8  |
|      8      |         Y          |    315971.6  |
|     16      |         N          |    315519.4  |
|     16      |         Y          |    315334.6  |
|     32      |         N          |    338909.0  |
|     32      |         Y          |    341660.5  |
 -------------------------------------------------
```